### PR TITLE
Add #va-claims to channel guide

### DIFF
--- a/community/slack_channel_guide.md
+++ b/community/slack_channel_guide.md
@@ -29,6 +29,7 @@ There is plenty of overlap; don't fret about it too much.
 | #language-wars | Or argue about which is better here |
 | #rants | Or rant about anything else here |
 | #active_duty | Active duty / Reserve developers who want to use skills to benefit their military organization |
+| #va-claims | A place to discuss anything to do with Veterans Affairs and related compensation cases |
 | #townhall | Weekly townhalls happen at 9PM Eastern Time every Thursday! Come join us |
 | #coding-interviews | Get help on algorithims and coding problems for job interviews or fun |
 | #colleges | Selecting a college, major/field of study, courses and electives, career specific programs, funding/financial aid options, tuition assistance/reimbursement programs |


### PR DESCRIPTION
#va-claims is a rather active channel. It would be useful to have in the channel guide.