### PR TITLE
Alphabetize Slack Channel Guide Table Entries

### DIFF
--- a/community/slack_channel_guide.md
+++ b/community/slack_channel_guide.md
@@ -4,49 +4,49 @@ There is plenty of overlap; don't fret about it too much.
 
 | Channel | Description |
 | --------- |:--------------:|
-| #general | General chatter, introductions, announcements, slackbots, try to keep it relatively clear |
-| #random | Whatever you crazy kids want. Just no politics or religion or you'll be tsk'ed at |
-| #freebies | A channel full of free stuff, reacting to any message with :freebie: will make it show there |
-| #career_advice | Ask for a resume review, career advice, questions about job offers |
-| #job_board | Post job opportunities, discuss job opportunity specifics |
-| #compensation | Come talk money and gettin paid |
-| #daily-programmer | Get a daily coding challenge to help yourself learn and grow |
-| #help | Ask us anything (probably about tech, but maybe not? I don't know!) Yes, even if you're new to all this, so are lots of people. |
-| #python | Talk Python |
-| #dotnet | Talk about .net development |
-| #javascript | Talk about Javascript. Hardcore javascript or not |
-| #java | Java and JVM talk |
-| #angular | Talk about Angular, AngularJs and all that components stuff |
-| #ruby | All of the Rubies! |
-| #reactjs | Cause #angular is a thing |
-| #web-dev | More broad discussions of web development, as well as html and css |
-| #cyber-security | Hacking and blocking that hackorz. Only channel where talking about how cool Bruce Schneier was is acceptable. |
-| #data-science | All your NumPys and SciPis and Rs |
-| #blockchain | Talk about blockchain technology (but not crypto trading) |
-| #crypto_trading_chat | Talk about crypto trading (but not the blockchain technology maybe?) |
-| #git | git questions can go here |
-| #vim | vim? Sure! |
-| #devops | Ops up your dev with ci servers and dockers and all that stuff |
-| #language-wars | Argue about which language is best |
-| #rants | Rant about anything else here |
 | #active_duty | Active duty / Reserve developers who want to use skills to benefit their military organization |
-| #va-claims | A place to discuss anything to do with Veterans Affairs and related compensation cases |
-| #transitioning | Space to share your experiences (positive and negative) of transitioning out of the military |
+| #android | All things Android |
+| #angular | Talk about Angular, AngularJs and all that components stuff |
+| #badjokes | This channel is a huge disappointment to us all, but it is fun |
+| #basic-algorithms | Learn some programming algorithms and get help if you need it |
+| #blockchain | Talk about blockchain technology (but not crypto trading) |
+| #career_advice | Ask for a resume review, career advice, questions about job offers |
 | #coding-interviews | Get help on algorithims and coding problems for job interviews or fun |
 | #colleges | Selecting a college, major/field of study, courses and electives, career specific programs, funding/financial aid options, tuition assistance/reimbursement programs |
-| #database | All about databases - creating, using, and admin |
-| #salesforce | Learn about SalesForce and SalesForce development |
-| #android | All things Android |
-| #linux | sudo apt-get linux chat |
-| #basic-algorithms | Learn some programming algorithms and get help if you need it |
+| #compensation | Come talk money and gettin paid |
 | #computer-science | Talk about the science of computers |
+| #cooking | Learn how to feed yourself |
+| #crypto_trading_chat | Talk about crypto trading (but not the blockchain technology maybe?) |
+| #cyber-security | Hacking and blocking that hackorz. Only channel where talking about how cool Bruce Schneier was is acceptable. |
+| #daily-programmer | Get a daily coding challenge to help yourself learn and grow |
+| #data-science | All your NumPys and SciPis and Rs |
+| #database | All about databases - creating, using, and admin |
+| #devops | Ops up your dev with ci servers and dockers and all that stuff |
+| #dotnet | Talk about .net development |
+| #entrepreneurship | Have a business? Want to have a business? Come talk about that here |
+| #freebies | A channel full of free stuff, reacting to any message with :freebie: will make it show there |
+| #gaming | Games on games on games on games |
+| #general | General chatter, introductions, announcements, slackbots, try to keep it relatively clear |
+| #git | git questions can go here |
+| #help | Ask us anything (probably about tech, but maybe not? I don't know!) Yes, even if you're new to all this, so are lots of people. |
 | #home-improvement | Get some tips on keeping your place looking as clean as your code |
+| #java | Java and JVM talk |
+| #javascript | Talk about Javascript. Hardcore javascript or not |
+| #job_board | Post job opportunities, discuss job opportunity specifics |
+| #language-wars | Argue about which language is best |
+| #linux | sudo apt-get linux chat |
+| #mental-health | Get information on mental health |
+| #milspouses | Resources and discussions centered around the spouses we love |
 | #oc-projects | Help us with our open-source projects |
 | #oc-python-projects | Help us with out open-source Python projects |
+| #python | Talk Python |
+| #random | Whatever you crazy kids want. Just no politics or religion or you'll be tsk'ed at |
+| #rants | Rant about anything else here |
 | #raspberrypi | Discuss the RPi computers and all the cool things they can do |
-| #badjokes | This channel is a huge disappointment to us all, but it is fun |
-| #milspouses | Resources and discussions centered around the spouses we love |
-| #mental-health | Get information on mental health |
-| #cooking | Learn how to feed yourself |
-| #gaming | Games on games on games on games |
-| #entrepreneurship | Have a business? Want to have a business? Come talk about that here |
+| #reactjs | Cause #angular is a thing |
+| #ruby | All of the Rubies! |
+| #salesforce | Learn about SalesForce and SalesForce development |
+| #transitioning | Space to share your experiences (positive and negative) of transitioning out of the military |
+| #va-claims | A place to discuss anything to do with Veterans Affairs and related compensation cases |
+| #vim | vim? Sure! |
+| #web-dev | More broad discussions of web development, as well as html and css |


### PR DESCRIPTION
It was mentioned that PRs are welcomed for the Slack channel guide, and I couldn't help but notice that the channels were not in alphabetical order. I discussed on the general channel and found out that there was a desire to make this happen, so here we go!