### PR TITLE
Add language: Prohibition of Impersonation of OC Mods or Staff

### DIFF
--- a/community/code_of_conduct.md
+++ b/community/code_of_conduct.md
@@ -99,6 +99,8 @@ In the cases of severe violations of the Code of Conduct (including but not limi
 
 This process applies to all Operation Code members, staff, partners, community, and anyone else who interacts with the Operation Code organization.
 
+*Impersonating an Operation Code Moderator or Staff member is prohibited and will result in an automatic ban.*
+
 ### Creating Additional Accounts ("Sockpuppeting")
 
 Attempting to get around a temporary or permanent ban by creating a new account in the Operation Code Slack will result in an immediate permanent ban.


### PR DESCRIPTION
Fixes #56 

Added new reinforcement language right before "SockPuppeting" in the Code of Conduct:

*Impersonating an Operation Code Moderator or Staff member is prohibited and will result in an automatic ban.*

@datphotogurl for review.